### PR TITLE
oauth_callback_url cleanup

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -13,7 +13,6 @@ __version__ = "1.5.2"
 
 import urllib
 import re
-import inspect
 import time
 
 import requests


### PR DESCRIPTION
There is some old stuff in twython.py related to the detection of the callback_url parameter in the oauth2 library that is not needed anymore. These changes clean that up.
