### PR TITLE
I fixed line 479 to properly URL encode the querystring (q parameter) fo...

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -476,7 +476,7 @@ class Twython(object):
                 e.g x.searchGen("python", page="2") or
                     x.searchGen(search_query = "python", page = "2")
         """
-        searchURL = Twython.constructApiURL("http://search.twitter.com/search.json?q=%s" % Twython.unicode2utf8(search_query), kwargs)
+        searchURL = Twython.constructApiURL("http://search.twitter.com/search.json?q=%s" % urllib.quote_plus(Twython.unicode2utf8(search_query)), kwargs)
         try:
             response = self.client.get(searchURL, headers=self.headers)
             data = simplejson.loads(response.content.decode('utf-8'))


### PR DESCRIPTION
...r the search functionality. According to http://dev.twitter.com/doc/get/search, the q parameter should be URL encoded, but Twython.unicode2utf8 doesn't urlencode the query.

So I enclosed it in a urllib.quote_plus function call.

examples: 

> > > urllib.quote_plus(Twython.unicode2utf8('h ^&$'))
> > > 'h+%5E%26%24'  
> > > Twython.unicode2utf8('h ^&$')
> > > 'h ^&$'
