### PR TITLE
corrected issue when searches with "q" gets encoded twice

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -427,7 +427,7 @@ class Twython(object):
             e.g x.search(q='jjndf', page='2')
         """
         if 'q' in kwargs:
-            kwargs['q'] = urllib.quote_plus(Twython.unicode2utf8(kwargs['q']))
+            kwargs['q'] = urllib.quote_plus(Twython.unicode2utf8(kwargs['q'], ':'))
 
         return self.get('https://search.twitter.com/search.json', params=kwargs)
 


### PR DESCRIPTION
When doing a search, the q parameter gets encoded twice.

Example:

code:
twitter = twython.Twython()
results = twitter.search(q='from:username')

result:
request via GET sending q=from%253Ausername

expected result:
request via GET sending q=from%3Ausername

The value is encoded on search:
kwargs['q'] = urllib.quote_plus(Twython.unicode2utf8(kwargs['q']))

and then on _request:
url = '%s?%s' % (url, urllib.urlencode(params))

I fixed It by passing a safe character to quote_plus:
kwargs['q'] = urllib.quote_plus(Twython.unicode2utf8(kwargs['q']), ':')
