### PR TITLE
Supported Proxies

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -162,7 +162,6 @@ class Twython(object):
         if self.client is None:
             # If they don't do authentication, but still want to request
             # unprotected resources, we need an opener.
-            print proxies
             self.client = requests.session(proxies=proxies)
 
         # register available funcs to allow listing name when debugging.


### PR DESCRIPTION
I made a small change to use twython on proxies (as I said before on twitter).

I added an argument "proxies" in Twython.**init** to specifiy the proxy. So it can be used as follows:

``` python
twitter = Twython(proxies={"http":"proxy.example.org:8080", "https":"proxy.example.org:8081"})
```
