### PR TITLE
Fixed broken params kwargs which was breaking updateStatusWithMedia

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -435,8 +435,8 @@ class Twython(object):
         url = 'https://api.twitter.com/%d/account/update_profile_background_image.json' % version
         return self._media_update(url,
                                   {'image': (file_, open(file_, 'rb'))},
-                                  params={'tile': tile})
-    
+                                  **{'tile': tile})
+
     def bulkUserLookup(self, **kwargs):
         """Stub for a method that has been deprecated, kept for now to raise errors
             properly if people are relying on this (which they are...).
@@ -446,7 +446,7 @@ class Twython(object):
             DeprecationWarning,
             stacklevel=2
         )
-    
+
     def updateProfileImage(self, file_, version=1):
         """Updates the authenticating user's profile image (avatar).
 
@@ -474,7 +474,7 @@ class Twython(object):
                                   {'media': (file_, open(file_, 'rb'))},
                                   **params)
 
-    def _media_update(self, url, file_, params=None):
+    def _media_update(self, url, file_, **params):
         return self.post(url, params=params, files=file_)
 
     def getProfileImageUrl(self, username, size='normal', version=1):


### PR DESCRIPTION
- params are passed as **kwargs everywhere else, so updated
  _media_update to be consistent with that.
- updated to updateProfileBackgroundImage to fall in line with
  _media_update changes.

Symptom of the problem is that updateStatusWithMedia was throwing:

``` python
TypeError: "_media_update() got an unexpected keyword argument 'status'" 
```

will also break for any other keyword argument as written.

With these rather small changes changes, all the media uploading calls should now work(most importantly the status updates). 
