### PR TITLE
2.3.4 release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 from setuptools import find_packages
 
 __author__ = 'Ryan McGrath <ryan@venodesigns.net>'
-__version__ = '2.3.3'
+__version__ = '2.3.4'
 
 setup(
     # Basic package information.
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
 
     # Package dependencies.
-    install_requires=['simplejson', 'requests>=0.13.2'],
+    install_requires=['simplejson', 'requests>=0.13.4'],
 
     # Metadata for PyPI.
     author='Ryan McGrath',

--- a/twython/twython.py
+++ b/twython/twython.py
@@ -9,7 +9,7 @@
 """
 
 __author__ = "Ryan McGrath <ryan@venodesigns.net>"
-__version__ = "2.3.3"
+__version__ = "2.3.4"
 
 import urllib
 import re
@@ -168,9 +168,7 @@ class Twython(object):
 
         func = getattr(self.client, method)
         if method == 'get':
-            # Still wasn't fixed in `requests` 0.13.2? :(
-            url = url + '?' + urllib.urlencode(params)
-            response = func(url)
+            response = func(url, params=params)
         else:
             response = func(url, data=params, files=files)
         content = response.content.decode('utf-8')
@@ -262,8 +260,7 @@ class Twython(object):
         if self.callback_url:
             request_args['oauth_callback'] = self.callback_url
 
-        req_url = self.request_token_url + '?' + urllib.urlencode(request_args)
-        response = self.client.get(req_url)
+        response = self.client.get(self.request_token_url, params=request_args)
 
         if response.status_code != 200:
             raise TwythonAuthError("Seems something couldn't be verified with your OAuth junk. Error: %s, Message: %s" % (response.status_code, response.content))
@@ -463,9 +460,9 @@ class Twython(object):
                             version Twitter has now
         """
         endpoint = 'users/profile_image/%s' % username
-        url = self.api_url % version + '/' + endpoint + '?' + urllib.urlencode({'size': size})
+        url = self.api_url % version + '/' + endpoint
 
-        response = self.client.get(url, allow_redirects=False)
+        response = self.client.get(url, params={'size': size}, allow_redirects=False)
         image_url = response.headers.get('location')
 
         if response.status_code in (301, 302, 303, 307) and image_url is not None:


### PR DESCRIPTION
requires requests 0.13.4 >
basically we don't have to url encode params anymore and can just pass a dict of params to the request (finally! :D)
