### PR TITLE
requests==0.14.0 requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     include_package_data=True,
 
     # Package dependencies.
-    install_requires=['simplejson', 'requests>=0.14.0'],
+    install_requires=['simplejson', 'requests==0.14.0'],
 
     # Metadata for PyPI.
     author='Ryan McGrath',


### PR DESCRIPTION
Requests needs to be on 0.14.0, otherwise calls with params and files will not work.
