### PR TITLE
Support for Friends and Followers list endpoints

### DIFF
--- a/twython/twitter_endpoints.py
+++ b/twython/twitter_endpoints.py
@@ -62,6 +62,14 @@ api_table = {
         'url': '/followers/ids.json',
         'method': 'GET',
     },
+    'getFriendsList': {
+        'url': '/friends/list.json',
+        'method': 'GET',
+    },
+    'getFollowersList': {
+        'url': '/followers/list.json',
+        'method': 'GET',
+    },
     'getIncomingFriendshipIDs': {
         'url': '/friendships/incoming.json',
         'method': 'GET',


### PR DESCRIPTION
"Two new methods in API v1.1 provide simplified access to user friend & follower data: https://dev.twitter.com/docs/api/1.1/get/followers/list … https://dev.twitter.com/docs/api/1.1/get/friends/list … ^TS" - @TwitterAPI
