### PR TITLE
Added ability to grab oembed html given a tweet id.

### DIFF
--- a/twython/twitter_endpoints.py
+++ b/twython/twitter_endpoints.py
@@ -339,6 +339,10 @@ api_table = {
         'url': '/report_spam.json',
         'method': 'POST',
     },
+    'getOembedTweet': {
+    'url': '/statuses/oembed.json',
+        'method': 'GET',
+    },
 }
 
 # from https://dev.twitter.com/docs/error-codes-responses


### PR DESCRIPTION
Needed to grab the oEmbed code to embed tweets for a site I'm working on that automatically grabs twitter data from a set of users. Not really much to it, but thought I would share.

Example code:

```
t = Twython(app_key=twitter_app_key,
        app_secret=twitter_app_secret,
        oauth_token=twitter_oauth_token,
        oauth_token_secret=twitter_oauth_token_secret)

t.getOembedTweet(id='insert tweet id')
```

This will return a json object with author_name, author_url, cache_age, height, html, provider_name, provider_url, url, version, and width.
