### PR TITLE
Update error code to 429 - (to catch rate limit exceptions)

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -203,6 +203,7 @@ class Twython(object):
                 'error', 'An error occurred processing your request.')
             self._last_call['api_error'] = error_msg
 
+            #Twitter API 1.1 , always return 429 when rate limit is exceeded
             exceptionType = TwythonRateLimitError if response.status_code == 429 else TwythonError
 
             raise exceptionType(error_msg,


### PR DESCRIPTION
Twitter Api 1.1 always returns the error_code: 429, when the rate limit is exceeded. This is different from the previous version where a variety of 400 response code were being returned.

https://dev.twitter.com/docs/rate-limiting/1.1

From the page:
_When an application exceeds the rate limit for a given API endpoint, the Twitter API will now return an HTTP 429 “Too Many Requests” response code instead of the variety of codes you would find across the v1's Search and REST APIs._
