### PR TITLE
if you dont pass in header you asked for explicitly all are returned. 

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -82,7 +82,7 @@ class TwythonRateLimitError(TwythonError):
 
 class Twython(object):
     def __init__(self, app_key=None, app_secret=None, oauth_token=None, oauth_token_secret=None, \
-                headers=None, callback_url=None, twitter_token=None, twitter_secret=None, proxies=None, version='1'):
+                headers=None, callback_url=None, twitter_token=None, twitter_secret=None, proxies=None, version='1.1'):
         """Instantiates an instance of Twython. Takes optional parameters for authentication and such (see below).
 
             :param app_key: (optional) Your applications key


### PR DESCRIPTION
- making it so that when you don't pass in header you get all of them back. 
- we really should be defaulting to 1.1
