### PR TITLE
Allow requests version higher than 0.14.0, but lower than 1.1.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
     include_package_data=True,
 
     # Package dependencies.
-    install_requires=['simplejson', 'requests==0.14.0'],
+    install_requires=['simplejson', 'requests>=0.14.0, <1.0.0'],
 
     # Metadata for PyPI.
     author='Ryan McGrath',


### PR DESCRIPTION
I was hoping we could get an official version of Twython with sub-1.1.0 requests requirements, but also not specifically pinned to 0.14.0. I have several other libraries that haven't made the jump yet to requests 1.0 (but are pinned to 0.14.1, for example) and this would allow me (and I'm sure others) to get the changes for Twitter's 1.1 API while limiting the update cascade that would result.

I tested this in my application and there were no issues I could find.

If you could get this in before #147, I would be much obliged.
