### PR TITLE
Added 'required' oauth_verifier to get_authorized_tokens.

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -298,7 +298,7 @@ class Twython(object):
     def get_authorized_tokens(self):
         """Returns authorized tokens after they go through the auth_url phase.
         """
-        response = self.client.get(self.access_token_url)
+        response = self.client.get(self.access_token_url,params={'oauth_verifier':self.oauth_token_secret})
         authorized_tokens = dict(parse_qsl(response.content))
         if not authorized_tokens:
             raise TwythonError('Unable to decode authorized tokens.')


### PR DESCRIPTION
When getting authorized tokens, the oauth_verifier was always optional. It was set to become required soon (which happened now). 

https://dev.twitter.com/docs/api/1/post/oauth/access_token

It's not yet updated in the docs. I added it in.
