### PR TITLE
Fixes #175, #177

### DIFF
--- a/twython/twitter_endpoints.py
+++ b/twython/twitter_endpoints.py
@@ -404,8 +404,11 @@ twitter_http_status_codes = {
     403: ('Forbidden', 'The request is understood, but it has been refused. An accompanying error message will explain why. This code is used when requests are being denied due to update limits.'),
     404: ('Not Found', 'The URI requested is invalid or the resource requested, such as a user, does not exists.'),
     406: ('Not Acceptable', 'Returned by the Search API when an invalid format is specified in the request.'),
-    420: ('Enhance Your Calm', 'Returned by the Search and Trends API when you are being rate limited.'),
+    410: ('Gone', 'This resource is gone. Used to indicate that an API endpoint has been turned off.'),
+    422: ('Unprocessable Entity', 'Returned when an image uploaded to POST account/update_profile_banner is unable to be processed.'),
+    429: ('Too Many Requests', 'Returned in API v1.1 when a request cannot be served due to the application\'s rate limit having been exhausted for the resource.'),
     500: ('Internal Server Error', 'Something is broken. Please post to the group so the Twitter team can investigate.'),
     502: ('Bad Gateway', 'Twitter is down or being upgraded.'),
     503: ('Service Unavailable', 'The Twitter servers are up, but overloaded with requests. Try again later.'),
+    504: ('Gateway Timeout', 'The Twitter servers are up, but the request couldn\'t be serviced due to some failure within our stack. Try again later.'),
 }


### PR DESCRIPTION
- Auth Errors are thrown in the correct spots
- Error messages are a lot cleaner than before and correspond with
  error codes on https://dev.twitter.com/docs/error-codes-responses
