### PR TITLE
Comments correction for get_lastfunction_header()

### DIFF
--- a/twython/twython.py
+++ b/twython/twython.py
@@ -258,10 +258,10 @@ class Twython(object):
             This will return None if the header is not present
 
             Most useful for the following header information:
-                x-ratelimit-limit
-                x-ratelimit-remaining
-                x-ratelimit-class
-                x-ratelimit-reset
+                x-rate-limit-limit
+                x-rate-limit-remaining
+                x-rate-limit-class
+                x-rate-limit-reset
         """
         if self._last_call is None:
             raise TwythonError('This function must be called after an API call.  It delivers header information.')


### PR DESCRIPTION
Headers have changed between 1.0 and 1.1. A  `-` is now needed between `rate` and `limit` (see [Rate limiting](https://dev.twitter.com/docs/rate-limiting/1.1)). I tried without and it doesn't work (return the whole header).
