### PR TITLE
search example update: twitter API v1.1 has replaced "rpp" by "count"

### DIFF
--- a/examples/search_results.py
+++ b/examples/search_results.py
@@ -3,7 +3,7 @@ from twython import Twython, TwythonError
 # Requires Authentication as of Twitter API v1.1
 twitter = Twython(APP_KEY, APP_SECRET, OAUTH_TOKEN, OAUTH_TOKEN_SECRET)
 try:
-    search_results = twitter.search(q='WebsDotCom', rpp='50')
+    search_results = twitter.search(q='WebsDotCom', count=50)
 except TwythonError as e:
     print e
 


### PR DESCRIPTION
Twitter API v1.1 has replaced "rpp" by "count" to set the number of tweets to return per page on a search query.

Thus, this patch simply update the twython search example.
