### PR TITLE
Refactor message handling in TwythonStreamer

### DIFF
--- a/twython/streaming/api.py
+++ b/twython/streaming/api.py
@@ -114,9 +114,8 @@ class TwythonStreamer(object):
                             for message_type in self.handlers:
                                 if message_type in data:
                                     handler = getattr(self, 'on_' + message_type, None)
-                                    if handler and callable(handler):
-                                        if not handler(data.get(message_type)):
-                                            break
+                                    if handler and callable(handler) and not handler(data.get(message_type)):
+                                        break
                     except ValueError:
                         self.on_error(response.status_code, 'Unable to decode response, not valid JSON.')
 


### PR DESCRIPTION
New parameter `handlers` has a list of message types for which
corresponding handlers should be called. For example, for default message types
['delete', 'limit', 'disconnect'] handlers on_delete, on_limit,
on_disconnect will be invoked if the streamed message has the
corresponding data node. If the handler returns True then more handlers
might be invoked, otherwise message processing stops. Before all
handlers are called, special on_success handler is invoked with the same
logic: continue message processing if True is returned.

This approach maintains backwards compatibility by not breaking any
existing behaviors. Fixes #223.
