### PR TITLE
Add optional sleep time to cursor 

### DIFF
--- a/twython/api.py
+++ b/twython/api.py
@@ -400,7 +400,7 @@ class Twython(EndpointsMixin, object):
 
         if not content:
             raise StopIteration
-
+        
         if hasattr(function, 'iter_key'):
             results = content.get(function.iter_key)
         else:


### PR DESCRIPTION
When using the cursor to get follower ids for a user with more than 75000 followers, the rate limit will always be exceeded, but there's no way to avoid that currently (I'm sure this is an issue for other endpoints as well). This change will allow you to pass an optional number of seconds that will cause it to sleep for that amount of time between each recursion.

For example, since the get_followers_ids endpoint has a limit of 15 calls per 15 minutes, this will never exceed the rate limit:

```
twitter.cursor(t.get_followers_ids, 60, id=123)
```

The change is backward compatible.
