### PR TITLE
Coerce elements to strings as fallback

### DIFF
--- a/twython/helpers.py
+++ b/twython/helpers.py
@@ -25,7 +25,10 @@ def _transparent_params(_params):
         elif isinstance(v, basestring) or isinstance(v, numeric_types):
             params[k] = v
         elif isinstance(v, list):
-            params[k] = ','.join(v)
+            try:
+                params[k] = ','.join(v)
+            except TypeError:
+                params[k] = ','.join(map(str,v))
         else:
             continue  # pragma: no cover
     return params, files


### PR DESCRIPTION
Returned objects from the APIs come back as `int`s in some cases. For example:

``` python
from twython import Twython
import random

tw = Twython(...)
followers = tw.get_followers_ids()['ids']
sample_users = random.sample(followers, 99)
user_data = tw.lookup_user(user_id=sample_users) # Will result in a type error
```

One workaround is to map these ahead of time:

``` python
tw.lookup_user(user_id=map(str,lonies))
```

This pull request just bakes it right in. We could coerce by default (which wouldn't affect strings).
