### PR TITLE
fix typo of APP_SECRET

### DIFF
--- a/docs/usage/starting_out.rst
+++ b/docs/usage/starting_out.rst
@@ -122,7 +122,7 @@ Obtain an OAuth 2 Access Token
 .. code-block:: python
 
     APP_KEY = 'YOUR_APP_KEY'
-    APP_SECET = 'YOUR_APP_SECRET'
+    APP_SECRET = 'YOUR_APP_SECRET'
 
     twitter = Twython(APP_KEY, APP_SECRET, oauth_version=2)
     ACCESS_TOKEN = twitter.obtain_access_token()


### PR DESCRIPTION
Found this when copy+pasting the example code.
