### PR TITLE
Don't mask TwythonStreamer exceptions

### DIFF
--- a/twython/streaming/api.py
+++ b/twython/streaming/api.py
@@ -139,14 +139,15 @@ class TwythonStreamer(object):
                         if is_py3:
                             line = line.decode('utf-8')
                         data = json.loads(line)
+                    except ValueError:  # pragma: no cover
+                        self.on_error(response.status_code, 'Unable to decode response, not valid JSON.')
+                    else:
                         if self.on_success(data):  # pragma: no cover
                             for message_type in self.handlers:
                                 if message_type in data:
                                     handler = getattr(self, 'on_' + message_type, None)
                                     if handler and callable(handler) and not handler(data.get(message_type)):
                                         break
-                    except ValueError:  # pragma: no cover
-                        self.on_error(response.status_code, 'Unable to decode response, not valid JSON.')
 
         response.close()
 


### PR DESCRIPTION
Exceptions in handlers or on_success which subclass ValueError would previously be caught and reported as a JSON decoding problem, and on_error() would be called (with status_code=200).

Note that, unrelated to this, you might want to catch handlers errors somehow, since it would certainly interrupt streaming.
