### PR TITLE
Extended streaming API interface maintaining backward compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ if sys.argv[-1] == 'publish':
 setup(
     name='twython',
     version=__version__,
-    install_requires=['requests==2.1.0', 'requests_oauthlib==0.4.0'],
+    install_requires=['requests>=2.1.0', 'requests_oauthlib>=0.4.0'],
     author='Ryan McGrath',
     author_email='ryan@venodesigns.net',
     license=open('LICENSE').read(),

--- a/twython/streaming/api.py
+++ b/twython/streaming/api.py
@@ -148,6 +148,7 @@ class TwythonStreamer(object):
                                     handler = getattr(self, 'on_' + message_type, None)
                                     if handler and callable(handler) and not handler(data.get(message_type)):
                                         break
+                        yield data
 
         response.close()
 
@@ -177,7 +178,9 @@ class TwythonStreamer(object):
         :param data: Error message sent from stream
         :type data: dict
         """
-        return
+        # Include the content
+        raise requests.exceptions.HTTPError(
+            response.status_code, response.content)
 
     def on_timeout(self):  # pragma: no cover
         """ Called when the request has timed out """

--- a/twython/streaming/types.py
+++ b/twython/streaming/types.py
@@ -28,7 +28,7 @@ class TwythonStreamerTypes(object):
         """
         url = 'https://userstream.twitter.com/%s/user.json' \
               % self.streamer.api_version
-        self.streamer._request(url, params=params)
+        return self.streamer._request(url, params=params)
 
     def site(self, **params):
         """Stream site
@@ -38,7 +38,7 @@ class TwythonStreamerTypes(object):
         """
         url = 'https://sitestream.twitter.com/%s/site.json' \
               % self.streamer.api_version
-        self.streamer._request(url, params=params)
+        return self.streamer._request(url, params=params)
 
 
 class TwythonStreamerTypesStatuses(object):
@@ -62,7 +62,7 @@ class TwythonStreamerTypesStatuses(object):
         """
         url = 'https://stream.twitter.com/%s/statuses/filter.json' \
               % self.streamer.api_version
-        self.streamer._request(url, 'POST', params=params)
+        return self.streamer._request(url, 'POST', params=params)
 
     def sample(self, **params):
         """Stream statuses/sample
@@ -74,7 +74,7 @@ class TwythonStreamerTypesStatuses(object):
         """
         url = 'https://stream.twitter.com/%s/statuses/sample.json' \
               % self.streamer.api_version
-        self.streamer._request(url, params=params)
+        return self.streamer._request(url, params=params)
 
     def firehose(self, **params):
         """Stream statuses/firehose
@@ -86,4 +86,4 @@ class TwythonStreamerTypesStatuses(object):
         """
         url = 'https://stream.twitter.com/%s/statuses/firehose.json' \
               % self.streamer.api_version
-        self.streamer._request(url, params=params)
+        return self.streamer._request(url, params=params)


### PR DESCRIPTION
The Twitter library by [sixohsix](https://github.com/sixohsix/twitter) implements the streams as generators, which is a very intuitive API and much easier to implement than the current one, where you have to subclass the streamer to implement several methods and possibly use queues to communicate between them.

```
stream = TwythonStreamer(consumer_key, consumer_secret, oauth_token, oauth_secret).user()
for tweet in stream:
    # Things and stuff
```

I originally replaced the old interface, which saves a lot of code, but this version maintains backward compatibility, except that errors are no longer silent by default.
