### PR TITLE
Adds retry_after attribute to TwythonRateLimitError

### DIFF
--- a/twython/exceptions.py
+++ b/twython/exceptions.py
@@ -53,6 +53,8 @@ class TwythonRateLimitError(TwythonError):  # pragma: no cover
             msg = '%s (Retry after %d seconds)' % (msg, retry_after)
         TwythonError.__init__(self, msg, error_code=error_code)
 
+        self.retry_after = retry_after
+
 
 class TwythonStreamError(TwythonError):
     """Raised when an invalid response from the Stream API is received"""


### PR DESCRIPTION
It is **awesome** that RateLimitErrors are bubble'd up through this library, great work!  Do you believe it would be useful to expose the retry_after value in the `TwythonRateLimitError` raised?

In using twython, I found myself wishing I could retrieve this value in the exception, so I created this quick patch. Please give me feedback or feel free to ignore this, if you do not believe it is useful for others :-) 

Thanks,
Cory

P.S. I was not able to run the test suite, as I do not have all of the necessary config vars set, testing it locally, it seemed to work okay. (Famous last words)
