### PR TITLE
Add missing comma in documentation code snippet

### DIFF
--- a/docs/usage/basic_usage.rst
+++ b/docs/usage/basic_usage.rst
@@ -22,7 +22,7 @@ Create a Twython instance with your application keys and the users OAuth tokens
 .. code-block:: python
 
     from twython import Twython
-    twitter = Twython(APP_KEY, APP_SECRET
+    twitter = Twython(APP_KEY, APP_SECRET,
                       OAUTH_TOKEN, OAUTH_TOKEN_SECRET)
 
 User Information


### PR DESCRIPTION
There's a comma missing in the code snippet
