### PR TITLE
Fix issue #317 TwythonRateLimitError.retry_after is always None.

### DIFF
--- a/twython/api.py
+++ b/twython/api.py
@@ -192,9 +192,10 @@ class Twython(EndpointsMixin, object):
                 # app keys/user tokens
                 ExceptionType = TwythonAuthError
 
-            raise ExceptionType(error_message,
-                                error_code=response.status_code,
-                                retry_after=response.headers.get('X-Rate-Limit-Reset'))
+            raise ExceptionType(
+                error_message,
+                error_code=response.status_code,
+                retry_after=response.headers.get('X-Rate-Limit-Reset'))
 
         try:
             content = response.json()


### PR DESCRIPTION
Got the proper retry_after value from the X-Rate-Limit-Reset header. 
