### PR TITLE
Adding upload media endpoint

### DIFF
--- a/twython/endpoints.py
+++ b/twython/endpoints.py
@@ -120,6 +120,16 @@ class EndpointsMixin(object):
         """
         return self.post('statuses/update_with_media', params=params)
 
+    def upload_media(self, **params):
+        """Uploads media file to Twitter servers. The file will be available to be attached
+        to a status for 60 minutes. To attach to a update, pass a list of returned media ids
+        to the 'update_status' method using the 'media_ids' param.
+
+        Docs:
+        https://dev.twitter.com/rest/public/uploading-media-multiple-photos
+        """
+        return self.post('https://upload.twitter.com/1.1/media/upload.json', params=params)
+
     def get_oembed_tweet(self, **params):
         """Returns information allowing the creation of an embedded
         representation of a Tweet on third party sites.


### PR DESCRIPTION
I started having some problems with update_with_media method and it looks like it's deprecated:
https://dev.twitter.com/rest/reference/post/statuses/update_with_media

The new method to update with media is described in here:
https://dev.twitter.com/rest/public/uploading-media-multiple-photos

This pull request adds `upload_media` method to twython so images can first be uploaded to twitter before they are attached to a update.  
I also added to docstring an explanation on how to proceed after uploading the media.
