### PR TITLE
Fixed TypeError

### DIFF
--- a/twython/api.py
+++ b/twython/api.py
@@ -214,6 +214,8 @@ class Twython(EndpointsMixin, object):
             # {"errors":[{"code":34,"message":"Sorry,
             # that page does not exist"}]}
             error_message = content['errors'][0]['message']
+        except TypeError:
+            error_message = content['errors']
         except ValueError:
             # bad json data from Twitter for an error
             pass


### PR DESCRIPTION
In some cases Twitter API returns only one error like this

```
{u'errors': u'sharing is not permissible for this status (Share validations failed)'}
```

But _get_error_message at api.py trying to catch 0th error message on response:

```
line 216 at api.py
error_message = content['errors'][0]['mesage']
```

That raises: TypeError: string indices must be integers

So i added an exception to handle this case. I'm waiting for your comments. Can we merge it to master?
