### PR TITLE
Have lookup_user GET and not POST

### DIFF
--- a/twython/endpoints.py
+++ b/twython/endpoints.py
@@ -458,7 +458,7 @@ class EndpointsMixin(object):
         Docs: https://dev.twitter.com/docs/api/1.1/get/users/lookup
 
         """
-        return self.post('users/lookup', params=params)
+        return self.get('users/lookup', params=params)
 
     def show_user(self, **params):
         """Returns a variety of information about the user specified by the


### PR DESCRIPTION
The documentation states that users/lookup requires a GET and not a POST. 
