### PR TITLE
Add support for quoted_status in html_for_tweet()

### DIFF
--- a/twython/api.py
+++ b/twython/api.py
@@ -528,7 +528,7 @@ class Twython(EndpointsMixin, object):
         return str(text)
 
     @staticmethod
-    def html_for_tweet(tweet, use_display_url=True, use_expanded_url=False):
+    def html_for_tweet(tweet, use_display_url=True, use_expanded_url=False, expand_quoted_status=False):
         """Return HTML for a tweet (urls, mentions, hashtags replaced with links)
 
         :param tweet: Tweet object from received from Twitter API
@@ -594,5 +594,17 @@ class Twython(EndpointsMixin, object):
                     url_html = '<a href="%s" class="twython-media">%s</a>'
                     text = text.replace(tweet['text'][start:end],
                                         url_html % (entity['url'], shown_url))
+
+        if expand_quoted_status and tweet['is_quote_status']:
+            quoted_status = tweet['quoted_status']
+            text += '<blockquote class="twython-quote">%(quote)s<cite><a href="%(quote_tweet_link)s">' \
+                    '<span class="twython-quote-user-name">%(quote_user_name)s</span>' \
+                    '<span class="twython-quote-user-screenname">@%(quote_user_screen_name)s</span></a>' \
+                    '</cite></blockquote>' % \
+                    {'quote': Twython.html_for_tweet(quoted_status, use_display_url, use_expanded_url, False),
+                     'quote_tweet_link': 'https://twitter.com/%s/status/%s' %
+                                         (quoted_status['user']['screen_name'], quoted_status['id_str']),
+                     'quote_user_name': quoted_status['user']['name'],
+                     'quote_user_screen_name': quoted_status['user']['screen_name']}
 
         return text


### PR DESCRIPTION
Example: Here's a quoted tweet #test https://twitter.com/Android/status/632196209797533696

Generated html (with linebreaks and comments for readability):

```html
Here's a quoted tweet <a href="https://twitter.com/search?q=%23test" class="twython-hashtag">#test</a> 
<a href="https://t.co/H3ru0zGahf" class="twython-url">twitter.com/Android/status…</a>
<!-- Added html for quoted tweet status -->
<blockquote class="twython-quote">
What’s <a href="https://twitter.com/search?q=%23Android" class="twython-hashtag">#Android</a> 
M gonna be? We all have our guesses… <a href="http://t.co/ofHffMu7ME" class="twython-url">g.co/go/NLwhatsM</a> 
<a href="https://twitter.com/search?q=%23natandlo" class="twython-hashtag">#natandlo</a> 
<a href="http://t.co/um6zpIdiw4" class="twython-media">pic.twitter.com/um6zpIdiw4</a>
<cite><a href="https://twitter.com/Android/632196209797533696">
<span class="twython-quote-user-name">Android</span><span class="twython-quote-user-screenname">@Android</span></a>
</cite></blockquote>
```
With Bootstrap:
![image](https://cloud.githubusercontent.com/assets/104607/9299219/475baa54-44ec-11e5-9a9a-9fbf4c5a519c.png)

With Bootstrap + custom css:
```css
blockquote.twython-quote { font-size: 1em; }
blockquote.twython-quote cite {
    display: block;
    font-style: normal;
    font-size: 0.9em;
}
blockquote.twython-quote cite:before { content: "— "; }
blockquote.twython-quote cite .twython-quote-user-name { font-weight: bold; }
blockquote.twython-quote cite .twython-quote-user-screenname:before { content: " ("; }
blockquote.twython-quote cite .twython-quote-user-screenname:after { content: ")"; }
```
![image](https://cloud.githubusercontent.com/assets/104607/9299221/4f4096b2-44ec-11e5-9d0b-b3c307bc6fc2.png)

