### PR TITLE
Add chunked video upload functionality

### DIFF
--- a/docs/usage/advanced_usage.rst
+++ b/docs/usage/advanced_usage.rst
@@ -35,6 +35,22 @@ Documentation:
 * https://dev.twitter.com/rest/reference/post/statuses/update
 * https://dev.twitter.com/rest/reference/post/media/upload
 
+Updating Status with Video
+--------------------------
+
+This uploads a video as a media object and associates it with a status update.
+
+.. code-block:: python
+
+    video = open('/path/to/file/video.mp4', 'rb')
+    response = twitter.upload_video(media=video, media_type='video/mp4')
+    twitter.update_status(status='Checkout this cool video!', media_ids=[response['media_id']])
+
+Documentation:
+
+* https://dev.twitter.com/rest/reference/post/statuses/update
+* https://dev.twitter.com/rest/reference/post/media/upload
+
 Posting a Status with an Editing Image
 --------------------------------------
 

--- a/twython/api.py
+++ b/twython/api.py
@@ -194,7 +194,10 @@ class Twython(EndpointsMixin, object):
                 retry_after=response.headers.get('X-Rate-Limit-Reset'))
 
         try:
-            content = response.json()
+            if response.status_code == 204:
+                content = response.content
+            else:
+                content = response.json()
         except ValueError:
             raise TwythonError('Response was not valid JSON. \
                                Unable to decode.')


### PR DESCRIPTION
This is a simple implementation of twitter's [chunked media upload api](https://dev.twitter.com/rest/public/uploading-media#chunkedupload). Following points need to be noted:

- I have added a separate endpoint for this instead of using the `upload_media`.
- It needs a media_type as required by twitter. Though in my own project, I am using python mimetypes module.
- It uses `.seek` to calculate size of media file if not given.
- As twitter have a limit of 5mb per chunk upload, I am uploading in 1mb chunks. I had to use `StringIO` as `helpers._transparent_params` is checking for `read` attribute on file contents.

Please let me know what you guys think.