### PR TITLE
Html for tweet no entities 2

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -317,3 +317,10 @@ class TwythonAPITestCase(unittest.TestCase):
         # Make sure HTML doesn't contain the display OR expanded url
         self.assertTrue('http://google.com' not in tweet_text)
         self.assertTrue('google.com' not in tweet_text)
+
+    def test_html_for_tweet_no_entities(self):
+        """Test HTML for tweet returns tweet text if it has no entities"""
+        tweet = test_tweet_object
+        del(tweet['entities'])
+        tweet_text = self.api.html_for_tweet(tweet)
+        self.assertEqual(tweet['text'], tweet_text)

--- a/twython/api.py
+++ b/twython/api.py
@@ -544,8 +544,9 @@ class Twython(EndpointsMixin, object):
         if 'retweeted_status' in tweet:
             tweet = tweet['retweeted_status']
 
+        text = tweet['text']
+
         if 'entities' in tweet:
-            text = tweet['text']
             entities = tweet['entities']
 
             # Mentions


### PR DESCRIPTION
Trying this again with a new branch...

I'm not 100% sure if it's possible any more to get tweet data that doesn't include entities. I've a feeling it might be, but can't find an example.

However, `html_for_tweet()` currently almost handles a tweet not having entities, except it throws `UnboundLocalError` because the `text` variable is declared in the wrong place. This fixes that.