### PR TITLE
Handle tweets having no 'entities'

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -324,3 +324,10 @@ class TwythonAPITestCase(unittest.TestCase):
         self.assertTrue('<a href="https://twitter.com/search?q=%24AAPL" class="twython-symbol">$AAPL</a>' in tweet_text)
         self.assertTrue('<a href="https://twitter.com/search?q=%24ANOTHER" class="twython-symbol">$ANOTHER</a>' not in tweet_text)
 
+    def test_html_for_tweet_no_entities(self):
+        """Test HTML for tweet returns tweet text if it has no entities"""
+        tweet = test_tweet_object
+        del(tweet['entities'])
+        tweet_text = self.api.html_for_tweet(tweet)
+        self.assertEqual(tweet['text'], tweet_text)
+

--- a/twython/api.py
+++ b/twython/api.py
@@ -544,8 +544,9 @@ class Twython(EndpointsMixin, object):
         if 'retweeted_status' in tweet:
             tweet = tweet['retweeted_status']
 
+        text = tweet['text']
+
         if 'entities' in tweet:
-            text = tweet['text']
             entities = tweet['entities']
 
             # Mentions


### PR DESCRIPTION
Trying again...

I'm not 100% sure if it's possible any more to get tweet data that doesn't include entities. I've a feeling it might be, but can't find an example.

However, `html_for_tweet()` currently almost handles a tweet not having entities, except it throws `UnboundLocalError` because the `text` variable is declared in the wrong place. This fixes that.