### PR TITLE
Use GET request if the media upload command is STATUS

### DIFF
--- a/twython/endpoints.py
+++ b/twython/endpoints.py
@@ -142,6 +142,10 @@ class EndpointsMixin(object):
         Docs:
         https://dev.twitter.com/rest/reference/post/media/upload
         """
+        # https://dev.twitter.com/rest/reference/get/media/upload-status
+        if params and params.get('command', '') == 'STATUS':
+            return self.get('https://upload.twitter.com/1.1/media/upload.json', params=params)
+
         return self.post('https://upload.twitter.com/1.1/media/upload.json', params=params)
 
     def upload_video(self, media, media_type, size=None):


### PR DESCRIPTION
Twitter recently announced support for longer duration videos https://twittercommunity.com/t/api-support-for-140-second-video/69153 but to take advantage of that, the media must be uploaded via the async method.

The async media upload method requires an additional STATUS command, but unlike the other commands such as INIT, APPEND, FINALIZE, the STATUS command is a GET request. The patch switches the upload_media endpoint to use self.get() if the command param is 'STATUS'.