### PR TITLE
Raise TypeError when cursor is not provided a callable

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -356,3 +356,15 @@ class TwythonAPITestCase(unittest.TestCase):
         tweet_text = self.api.html_for_tweet(test_tweet_extended_object)
         # full tweet rendered with suffix
         self.assertEqual(test_tweet_extended_html, tweet_text)
+
+    def test_cursor_requires_twython_function(self):
+        """Test that cursor() raises when called without a Twython function"""
+        def init_and_iterate_cursor(*args, **kwargs):
+            cursor = self.api.cursor(*args, **kwargs)
+            return next(cursor)
+
+        non_function = object()
+        non_twython_function = lambda x: x
+
+        self.assertRaises(TypeError, init_and_iterate_cursor, non_function)
+        self.assertRaises(TwythonError, init_and_iterate_cursor, non_twython_function)

--- a/twython/api.py
+++ b/twython/api.py
@@ -470,6 +470,11 @@ class Twython(EndpointsMixin, object):
           >>>   print result
 
         """
+        if not callable(function):
+            raise TypeError('.cursor() takes a Twython function as its first \
+                            argument. Did you provide the result of a \
+                            function call?')
+
         if not hasattr(function, 'iter_mode'):
             raise TwythonError('Unable to create generator for Twython \
                                method "%s"' % function.__name__)


### PR DESCRIPTION
This PR adds a check when creating a cursor to ensure that the first argument is callable. This fixes #452.