### PR TITLE
Added create_metadata endpoint

### DIFF
--- a/twython/api.py
+++ b/twython/api.py
@@ -140,7 +140,11 @@ class Twython(EndpointsMixin, object):
         params = params or {}
 
         func = getattr(self.client, method)
-        params, files = _transparent_params(params)
+        if type(params) is dict:
+            params, files = _transparent_params(params)
+        else:
+            params = params
+            files = list()
 
         requests_args = {}
         for k, v in self.client_args.items():
@@ -192,15 +196,16 @@ class Twython(EndpointsMixin, object):
                 error_message,
                 error_code=response.status_code,
                 retry_after=response.headers.get('X-Rate-Limit-Reset'))
-
+        content=""
         try:
             if response.status_code == 204:
                 content = response.content
             else:
                 content = response.json()
         except ValueError:
-            raise TwythonError('Response was not valid JSON. \
-                               Unable to decode.')
+            if response.content!="":
+                raise TwythonError('Response was not valid JSON. \
+                                   Unable to decode.')
 
         return content
 

--- a/twython/api.py
+++ b/twython/api.py
@@ -140,7 +140,7 @@ class Twython(EndpointsMixin, object):
         params = params or {}
 
         func = getattr(self.client, method)
-        if type(params) is dict:
+        if isinstance(params, dict):
             params, files = _transparent_params(params)
         else:
             params = params
@@ -196,14 +196,14 @@ class Twython(EndpointsMixin, object):
                 error_message,
                 error_code=response.status_code,
                 retry_after=response.headers.get('X-Rate-Limit-Reset'))
-        content=""
+        content = ''
         try:
             if response.status_code == 204:
                 content = response.content
             else:
                 content = response.json()
         except ValueError:
-            if response.content!="":
+            if response.content != '':
                 raise TwythonError('Response was not valid JSON. \
                                    Unable to decode.')
 

--- a/twython/endpoints.py
+++ b/twython/endpoints.py
@@ -14,6 +14,7 @@ This map is organized the order functions are documented at:
 https://dev.twitter.com/docs/api/1.1
 """
 
+import json
 import os
 import warnings
 from io import BytesIO
@@ -149,6 +150,13 @@ class EndpointsMixin(object):
             return self.get('https://upload.twitter.com/1.1/media/upload.json', params=params)
 
         return self.post('https://upload.twitter.com/1.1/media/upload.json', params=params)
+
+    def create_metadata(self, **params):
+        """ Adds metadata to a media element, such as image descriptions for visually impaired.
+        Docs: https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-metadata-create
+        """
+        params = json.dumps(params)
+        return self.post("https://upload.twitter.com/1.1/media/metadata/create.json", params=params)
 
     def upload_video(self, media, media_type, media_category=None, size=None, check_progress=False):
         """Uploads video file to Twitter servers in chunks. The file will be available to be attached


### PR DESCRIPTION
I have added the create_metadata endpoint for image descriptions. Now it should pass all tests. The following modifications have been made to api.py:

* JSON exception will raise only if response content is not empty.
* _transparent_params is only called if params is a dictionary
