### PR TITLE
Update links to Twitter docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,7 +24,7 @@ Features
     - Twitter lists
     - Timelines
     - Direct Messages
-    - and anything found in `the docs <https://dev.twitter.com/docs/api/1.1>`_
+    - and anything found in `the docs <https://developer.twitter.com/en/docs>`_
 - Image Uploading:
     - Update user status with an image
     - Change user avatar
@@ -67,7 +67,7 @@ Documentation is available at https://twython.readthedocs.io/en/latest/
 Starting Out
 ------------
 
-First, you'll want to head over to https://dev.twitter.com/apps and register an application!
+First, you'll want to head over to https://apps.twitter.com and register an application!
 
 After you register, grab your applications ``Consumer Key`` and ``Consumer Secret`` from the application details tab.
 
@@ -165,7 +165,7 @@ Create a Twython instance with your application keys and the users OAuth tokens
 Authenticated Users Home Timeline
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Documentation: https://dev.twitter.com/docs/api/1.1/get/statuses/home_timeline
+Documentation: https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-home_timeline
 
 .. code-block:: python
 
@@ -176,7 +176,7 @@ Updating Status
 
 This method makes use of dynamic arguments, `read more about them <https://twython.readthedocs.io/en/latest/usage/starting_out.html#dynamic-function-arguments>`_
 
-Documentation: https://dev.twitter.com/docs/api/1/post/statuses/update
+Documentation: https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update
 
 .. code-block:: python
 
@@ -185,7 +185,7 @@ Documentation: https://dev.twitter.com/docs/api/1/post/statuses/update
 Searching
 ~~~~~~~~~
 
-    https://dev.twitter.com/docs/api/1.1/get/search/tweets says it takes "q" and "result_type" amongst other arguments
+    https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets says it takes "q" and "result_type" amongst other arguments
 
 .. code-block:: python
 

--- a/docs/usage/basic_usage.rst
+++ b/docs/usage/basic_usage.rst
@@ -80,7 +80,7 @@ Documentation: https://developer.twitter.com/en/docs/tweets/search/api-reference
 
 .. _dynamicargexplaination:
 
-.. important:: To help explain :ref:`dynamic function arguments <dynamicfunctionarguments>` a little more, you can see that the previous call used the keyword argument ``q``, that is because Twitter specifies in their `search documentation <https://dev.twitter.com/docs/api/1.1/get/search/tweets>`_ that the search call accepts the parameter "q". You can pass mutiple keyword arguments. The search documentation also specifies that the call accepts the parameter "result_type"
+.. important:: To help explain :ref:`dynamic function arguments <dynamicfunctionarguments>` a little more, you can see that the previous call used the keyword argument ``q``, that is because Twitter specifies in their `search documentation <https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets>`_ that the search call accepts the parameter "q". You can pass mutiple keyword arguments. The search documentation also specifies that the call accepts the parameter "result_type"
 
 .. code-block:: python
 

--- a/twython/endpoints.py
+++ b/twython/endpoints.py
@@ -10,8 +10,8 @@ as a keyword argument.
 
 e.g. Twython.retweet(id=12345)
 
-This map is organized the order functions are documented at:
-https://dev.twitter.com/docs/api/1.1
+Official documentation for Twitter API endpoints can be found at:
+https://developer.twitter.com/en/docs/api-reference-index
 """
 
 import json
@@ -34,7 +34,7 @@ class EndpointsMixin(object):
         @screen_name) for the authenticating user.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/get/statuses/mentions_timeline
+        https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-mentions_timeline
 
         """
         return self.get('statuses/mentions_timeline', params=params)
@@ -44,7 +44,8 @@ class EndpointsMixin(object):
         """Returns a collection of the most recent Tweets posted by the user
         indicated by the screen_name or user_id parameters.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/statuses/user_timeline
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-user_timeline
 
         """
         return self.get('statuses/user_timeline', params=params)
@@ -54,7 +55,8 @@ class EndpointsMixin(object):
         """Returns a collection of the most recent Tweets and retweets
         posted by the authenticating user and the users they follow.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/statuses/home_timeline
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/timelines/api-reference/get-statuses-home_timeline
 
         """
         return self.get('statuses/home_timeline', params=params)
@@ -64,7 +66,8 @@ class EndpointsMixin(object):
         """Returns the most recent tweets authored by the authenticating user
         that have been retweeted by others.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/statuses/retweets_of_me
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweets_of_me
 
         """
         return self.get('statuses/retweets_of_me', params=params)
@@ -74,7 +77,8 @@ class EndpointsMixin(object):
     def get_retweets(self, **params):
         """Returns up to 100 of the first retweets of a given tweet.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/statuses/retweets/%3Aid
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-retweet-id
 
         """
         return self.get('statuses/retweets/%s' % params.get('id'),
@@ -83,7 +87,8 @@ class EndpointsMixin(object):
     def show_status(self, **params):
         """Returns a single Tweet, specified by the id parameter
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/statuses/show/%3Aid
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-show-id
 
         """
         return self.get('statuses/show/%s' % params.get('id'), params=params)
@@ -93,7 +98,8 @@ class EndpointsMixin(object):
         request, as specified by comma-separated values passed to the id
         parameter.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/statuses/lookup
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-lookup
 
         """
         return self.post('statuses/lookup', params=params)
@@ -101,7 +107,8 @@ class EndpointsMixin(object):
     def destroy_status(self, **params):
         """Destroys the status specified by the required ID parameter
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/statuses/destroy/%3Aid
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-destroy-id
 
         """
         return self.post('statuses/destroy/%s' % params.get('id'))
@@ -109,7 +116,8 @@ class EndpointsMixin(object):
     def update_status(self, **params):
         """Updates the authenticating user's current status, also known as tweeting
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/statuses/update
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update
 
         """
         return self.post('statuses/update', params=params)
@@ -117,7 +125,8 @@ class EndpointsMixin(object):
     def retweet(self, **params):
         """Retweets a tweet specified by the id parameter
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/statuses/retweet/%3Aid
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-retweet-id
 
         """
         return self.post('statuses/retweet/%s' % params.get('id'))
@@ -127,7 +136,7 @@ class EndpointsMixin(object):
         for upload. In other words, it creates a Tweet with a picture attached.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/statuses/update_with_media
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-statuses-update_with_media
 
         """
         warnings.warn(
@@ -143,9 +152,10 @@ class EndpointsMixin(object):
         to the 'update_status' method using the 'media_ids' param.
 
         Docs:
-        https://dev.twitter.com/rest/reference/post/media/upload
+        https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-upload
+
         """
-        # https://dev.twitter.com/rest/reference/get/media/upload-status
+        # https://developer.twitter.com/en/docs/media/upload-media/api-reference/get-media-upload-status
         if params and params.get('command', '') == 'STATUS':
             return self.get('https://upload.twitter.com/1.1/media/upload.json', params=params)
 
@@ -153,7 +163,10 @@ class EndpointsMixin(object):
 
     def create_metadata(self, **params):
         """ Adds metadata to a media element, such as image descriptions for visually impaired.
-        Docs: https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-metadata-create
+
+        Docs:
+        https://developer.twitter.com/en/docs/media/upload-media/api-reference/post-media-metadata-create
+
         """
         params = json.dumps(params)
         return self.post("https://upload.twitter.com/1.1/media/metadata/create.json", params=params)
@@ -171,7 +184,8 @@ class EndpointsMixin(object):
         Twitter media upload api expects each chunk to be not more than 5mb. We are sending chunk of 1mb each.
 
         Docs:
-        https://dev.twitter.com/rest/public/uploading-media#chunkedupload
+        https://developer.twitter.com/en/docs/media/upload-media/uploading-media/chunked-media-upload
+
         """
         upload_url = 'https://upload.twitter.com/1.1/media/upload.json'
         if not size:
@@ -216,7 +230,7 @@ class EndpointsMixin(object):
 
         response = self.post(upload_url, params=params)
 
-        # Only get the status if explicity asked to 
+        # Only get the status if explicity asked to
         # Default to False
         if check_progress:
 
@@ -250,7 +264,8 @@ class EndpointsMixin(object):
         """Returns information allowing the creation of an embedded
         representation of a Tweet on third party sites.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/statuses/oembed
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-oembed
 
         """
         return self.get('statuses/oembed', params=params)
@@ -259,7 +274,8 @@ class EndpointsMixin(object):
         """Returns a collection of up to 100 user IDs belonging to users who
         have retweeted the tweet specified by the id parameter.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/statuses/retweeters/ids
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-statuses-retweeters-ids
 
         """
         return self.get('statuses/retweeters/ids', params=params)
@@ -270,7 +286,8 @@ class EndpointsMixin(object):
     def search(self, **params):
         """Returns a collection of relevant Tweets matching a specified query.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/search/tweets
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets
 
         """
         return self.get('search/tweets', params=params)
@@ -282,7 +299,8 @@ class EndpointsMixin(object):
     def get_direct_messages(self, **params):
         """Returns the 20 most recent direct messages sent to the authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/direct_messages
+        Docs:
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-messages
 
         """
         return self.get('direct_messages', params=params)
@@ -291,7 +309,8 @@ class EndpointsMixin(object):
     def get_sent_messages(self, **params):
         """Returns the 20 most recent direct messages sent by the authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/direct_messages/sent
+        Docs:
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-sent-message
 
         """
         return self.get('direct_messages/sent', params=params)
@@ -300,7 +319,8 @@ class EndpointsMixin(object):
     def get_direct_message(self, **params):
         """Returns a single direct message, specified by an id parameter.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/direct_messages/show
+        Docs:
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-message
 
         """
         return self.get('direct_messages/show', params=params)
@@ -308,7 +328,8 @@ class EndpointsMixin(object):
     def destroy_direct_message(self, **params):
         """Destroys the direct message specified in the required id parameter
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/direct_messages/destroy
+        Docs:
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message
 
         """
         return self.post('direct_messages/destroy', params=params)
@@ -317,7 +338,8 @@ class EndpointsMixin(object):
         """Sends a new direct message to the specified user from the
         authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/direct_messages/new
+        Docs:
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-message
 
         """
         return self.post('direct_messages/new', params=params)
@@ -328,7 +350,7 @@ class EndpointsMixin(object):
         user does not want to receive retweets from.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/get/friendships/no_retweets/ids
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-no_retweets-ids
 
         """
         return self.get('friendships/no_retweets/ids', params=params)
@@ -337,7 +359,8 @@ class EndpointsMixin(object):
         """Returns a cursored collection of user IDs for every user the
         specified user is following (otherwise known as their "friends").
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/friends/ids
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-ids
 
         """
         return self.get('friends/ids', params=params)
@@ -348,7 +371,8 @@ class EndpointsMixin(object):
         """Returns a cursored collection of user IDs for every user
         following the specified user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/followers/ids
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-ids
 
         """
         return self.get('followers/ids', params=params)
@@ -359,7 +383,8 @@ class EndpointsMixin(object):
         """Returns the relationships of the authenticating user to the
         comma-separated list of up to 100 screen_names or user_ids provided.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/friendships/lookup
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-lookup
 
         """
         return self.get('friendships/lookup', params=params)
@@ -368,7 +393,8 @@ class EndpointsMixin(object):
         """Returns a collection of numeric IDs for every user who has a
         pending request to follow the authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/friendships/incoming
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-incoming
 
         """
         return self.get('friendships/incoming', params=params)
@@ -379,7 +405,8 @@ class EndpointsMixin(object):
         """Returns a collection of numeric IDs for every protected user for
         whom the authenticating user has a pending follow request.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/friendships/outgoing
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-outgoing
 
         """
         return self.get('friendships/outgoing', params=params)
@@ -390,7 +417,8 @@ class EndpointsMixin(object):
         """Allows the authenticating users to follow the user specified
         in the ID parameter.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/friendships/create
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/post-friendships-create
 
         """
         return self.post('friendships/create', params=params)
@@ -399,7 +427,8 @@ class EndpointsMixin(object):
         """Allows the authenticating user to unfollow the user specified
         in the ID parameter.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/friendships/destroy
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/post-friendships-destroy
 
         """
         return self.post('friendships/destroy', params=params)
@@ -408,7 +437,8 @@ class EndpointsMixin(object):
         """Allows one to enable or disable retweets and device notifications
         from the specified user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/friendships/update
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/post-friendships-update
 
         """
         return self.post('friendships/update', params=params)
@@ -417,7 +447,8 @@ class EndpointsMixin(object):
         """Returns detailed information about the relationship between two
         arbitrary users.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/friendships/show
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friendships-show
 
         """
         return self.get('friendships/show', params=params)
@@ -426,7 +457,8 @@ class EndpointsMixin(object):
         """Returns a cursored collection of user objects for every user the
         specified user is following (otherwise known as their "friends").
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/friends/list
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-friends-list
 
         """
         return self.get('friends/list', params=params)
@@ -437,7 +469,8 @@ class EndpointsMixin(object):
         """Returns a cursored collection of user objects for users
         following the specified user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/followers/list
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-followers-list
 
         """
         return self.get('followers/list', params=params)
@@ -449,7 +482,8 @@ class EndpointsMixin(object):
         """Returns settings (including current trend, geo and sleep time
         information) for the authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/account/settings
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-settings
 
         """
         return self.get('account/settings', params=params)
@@ -460,7 +494,7 @@ class EndpointsMixin(object):
         code and an error message if not.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/get/account/verify_credentials
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-account-verify_credentials
 
         """
         return self.get('account/verify_credentials', params=params)
@@ -468,7 +502,8 @@ class EndpointsMixin(object):
     def update_account_settings(self, **params):
         """Updates the authenticating user's settings.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/account/settings
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-settings
 
         """
         return self.post('account/settings', params=params)
@@ -486,7 +521,8 @@ class EndpointsMixin(object):
         """Sets values that users are able to set under the "Account" tab of their
         settings page.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/account/update_profile
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile
 
         """
         return self.post('account/update_profile', params=params)
@@ -495,26 +531,35 @@ class EndpointsMixin(object):
         """Updates the authenticating user's profile background image.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/account/update_profile_background_image
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_background_image
 
         """
         return self.post('account/update_profile_banner', params=params)
 
-    def update_profile_colors(self, **params):
+    def update_profile_colors(self, **params): # pragma: no cover
         """Sets one or more hex values that control the color scheme of the
         authenticating user's profile page on twitter.com.
 
+        This method is deprecated, replaced by the profile_link_color
+        parameter to update_profile.
+
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/account/update_profile_colors
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile
 
         """
+        warnings.warn(
+            'This method is deprecated. You should use the'
+            ' profile_link_color parameter in Twython.update_profile instead.',
+            TwythonDeprecationWarning,
+            stacklevel=2
+        )
         return self.post('account/update_profile_colors', params=params)
 
     def update_profile_image(self, **params):  # pragma: no cover
         """Updates the authenticating user's profile image.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/account/update_profile_image
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_image
 
         """
         return self.post('account/update_profile_image', params=params)
@@ -523,7 +568,8 @@ class EndpointsMixin(object):
         """Returns a collection of user objects that the authenticating user
         is blocking.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/blocks/list
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-blocks-list
 
         """
         return self.get('blocks/list', params=params)
@@ -533,7 +579,8 @@ class EndpointsMixin(object):
     def list_block_ids(self, **params):
         """Returns an array of numeric user ids the authenticating user is blocking.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/blocks/ids
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-blocks-ids
 
         """
         return self.get('blocks/ids', params=params)
@@ -543,7 +590,8 @@ class EndpointsMixin(object):
     def create_block(self, **params):
         """Blocks the specified user from following the authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/blocks/create
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-blocks-create
 
         """
         return self.post('blocks/create', params=params)
@@ -552,7 +600,8 @@ class EndpointsMixin(object):
         """Un-blocks the user specified in the ID parameter for the
         authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/blocks/destroy
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-blocks-destroy
 
         """
         return self.post('blocks/destroy', params=params)
@@ -562,7 +611,8 @@ class EndpointsMixin(object):
         as specified by comma-separated values passed to the user_id and/or
         screen_name parameters.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/users/lookup
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-lookup
 
         """
         return self.get('users/lookup', params=params)
@@ -571,7 +621,8 @@ class EndpointsMixin(object):
         """Returns a variety of information about the user specified by the
         required user_id or screen_name parameter.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/users/show
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-show
 
         """
         return self.get('users/show', params=params)
@@ -580,7 +631,8 @@ class EndpointsMixin(object):
         """Provides a simple, relevance-based search interface to public user
         accounts on Twitter.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/users/search
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-search
 
         """
         return self.get('users/search', params=params)
@@ -606,7 +658,7 @@ class EndpointsMixin(object):
         Returns HTTP 200 upon success.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/account/remove_profile_banner
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-remove_profile_banner
 
         """
         return self.post('account/remove_profile_banner', params=params)
@@ -615,7 +667,7 @@ class EndpointsMixin(object):
         """Uploads a profile banner on behalf of the authenticating user.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/account/update_profile_banner
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/post-account-update_profile_banner
 
         """
         return self.post('account/update_profile_background_image',
@@ -625,7 +677,8 @@ class EndpointsMixin(object):
         """Returns a map of the available size variations of the specified
         user's profile banner.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/users/profile_banner
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/manage-account-settings/api-reference/get-users-profile_banner
 
         """
         return self.get('users/profile_banner', params=params)
@@ -634,7 +687,8 @@ class EndpointsMixin(object):
         """Returns a collection of user objects that the authenticating user
         is muting.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/mutes/users/list
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-list
 
         """
         return self.get('mutes/users/list', params=params)
@@ -645,7 +699,8 @@ class EndpointsMixin(object):
         """Returns an array of numeric user ids the authenticating user
         is muting.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/mutes/users/ids
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/get-mutes-users-ids
 
         """
         return self.get('mutes/users/ids', params=params)
@@ -656,7 +711,8 @@ class EndpointsMixin(object):
         """Mutes the specified user, preventing their tweets appearing
         in the authenticating user's timeline.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/mutes/users/create
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
 
         """
         return self.post('mutes/users/create', params=params)
@@ -665,7 +721,8 @@ class EndpointsMixin(object):
         """Un-mutes the user specified in the user or ID parameter for
         the authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/mutes/users/destroy
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-destroy
 
         """
         return self.post('mutes/users/destroy', params=params)
@@ -675,7 +732,7 @@ class EndpointsMixin(object):
         """Access the users in a given category of the Twitter suggested user list.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/get/users/suggestions/%3Aslug
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-suggestions-slug
 
         """
         return self.get('users/suggestions/%s' % params.get('slug'),
@@ -684,7 +741,8 @@ class EndpointsMixin(object):
     def get_user_suggestions(self, **params):
         """Access to Twitter's suggested user list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/users/suggestions
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-suggestions
 
         """
         return self.get('users/suggestions', params=params)
@@ -695,7 +753,7 @@ class EndpointsMixin(object):
         user.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/get/users/suggestions/%3Aslug/members
+        https://developer.twitter.com/en/docs/accounts-and-users/follow-search-get-users/api-reference/get-users-suggestions-slug-members
 
         """
         return self.get('users/suggestions/%s/members' % params.get('slug'),
@@ -706,7 +764,8 @@ class EndpointsMixin(object):
         """Returns the 20 most recent Tweets favorited by the authenticating
         or specified user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/favorites/list
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/get-favorites-list
 
         """
         return self.get('favorites/list', params=params)
@@ -716,7 +775,8 @@ class EndpointsMixin(object):
         """Un-favorites the status specified in the ID parameter as the
         authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/favorites/destroy
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-favorites-destroy
 
         """
         return self.post('favorites/destroy', params=params)
@@ -725,7 +785,8 @@ class EndpointsMixin(object):
         """Favorites the status specified in the ID parameter as the
         authenticating user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/favorites/create
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/post-and-engage/api-reference/post-favorites-create
 
         """
         return self.post('favorites/create', params=params)
@@ -735,7 +796,8 @@ class EndpointsMixin(object):
         """Returns all lists the authenticating or specified user subscribes to,
         including their own.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/list
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-list
 
         """
         return self.get('lists/list', params=params)
@@ -743,7 +805,8 @@ class EndpointsMixin(object):
     def get_list_statuses(self, **params):
         """Returns a timeline of tweets authored by members of the specified list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/statuses
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-statuses
 
         """
         return self.get('lists/statuses', params=params)
@@ -752,7 +815,8 @@ class EndpointsMixin(object):
     def delete_list_member(self, **params):
         """Removes the specified member from the list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/lists/members/destroy
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy
 
         """
         return self.post('lists/members/destroy', params=params)
@@ -760,7 +824,8 @@ class EndpointsMixin(object):
     def get_list_memberships(self, **params):
         """Returns the lists the specified user has been added to.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/memberships
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-memberships
 
         """
         return self.get('lists/memberships', params=params)
@@ -770,7 +835,8 @@ class EndpointsMixin(object):
     def get_list_subscribers(self, **params):
         """Returns the subscribers of the specified list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/subscribers
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscribers
 
         """
         return self.get('lists/subscribers', params=params)
@@ -781,7 +847,7 @@ class EndpointsMixin(object):
         """Subscribes the authenticated user to the specified list.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/lists/subscribers/create
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-subscribers-create
 
         """
         return self.post('lists/subscribers/create', params=params)
@@ -789,7 +855,8 @@ class EndpointsMixin(object):
     def is_list_subscriber(self, **params):
         """Check if the specified user is a subscriber of the specified list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/subscribers/show
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscribers-show
 
         """
         return self.get('lists/subscribers/show', params=params)
@@ -798,7 +865,7 @@ class EndpointsMixin(object):
         """Unsubscribes the authenticated user from the specified list.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/lists/subscribers/destroy
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-subscribers-destroy
 
         """
         return self.post('lists/subscribers/destroy', params=params)
@@ -808,7 +875,7 @@ class EndpointsMixin(object):
         list of member ids or screen names.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/lists/members/create_all
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-members-create_all
 
         """
         return self.post('lists/members/create_all', params=params)
@@ -816,7 +883,8 @@ class EndpointsMixin(object):
     def is_list_member(self, **params):
         """Check if the specified user is a member of the specified list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/members/show
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members-show
 
         """
         return self.get('lists/members/show', params=params)
@@ -824,7 +892,8 @@ class EndpointsMixin(object):
     def get_list_members(self, **params):
         """Returns the members of the specified list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/members
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-members
 
         """
         return self.get('lists/members', params=params)
@@ -834,7 +903,8 @@ class EndpointsMixin(object):
     def add_list_member(self, **params):
         """Add a member to a list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/lists/members/create
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-members-create
 
         """
         return self.post('lists/members/create', params=params)
@@ -842,7 +912,8 @@ class EndpointsMixin(object):
     def delete_list(self, **params):
         """Deletes the specified list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/lists/destroy
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-destroy
 
         """
         return self.post('lists/destroy', params=params)
@@ -850,7 +921,8 @@ class EndpointsMixin(object):
     def update_list(self, **params):
         """Updates the specified list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/lists/update
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-update
 
         """
         return self.post('lists/update', params=params)
@@ -858,7 +930,8 @@ class EndpointsMixin(object):
     def create_list(self, **params):
         """Creates a new list for the authenticated user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/lists/create
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-create
 
         """
         return self.post('lists/create', params=params)
@@ -866,7 +939,8 @@ class EndpointsMixin(object):
     def get_specific_list(self, **params):
         """Returns the specified list.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/show
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-show
 
         """
         return self.get('lists/show', params=params)
@@ -874,7 +948,8 @@ class EndpointsMixin(object):
     def get_list_subscriptions(self, **params):
         """Obtain a collection of the lists the specified user is subscribed to.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/subscriptions
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-subscriptions
 
         """
         return self.get('lists/subscriptions', params=params)
@@ -886,7 +961,7 @@ class EndpointsMixin(object):
         comma-separated list of member ids or screen names.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/lists/members/destroy_all
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/post-lists-members-destroy_all
 
         """
         return self.post('lists/members/destroy_all', params=params)
@@ -894,7 +969,8 @@ class EndpointsMixin(object):
     def show_owned_lists(self, **params):
         """Returns the lists owned by the specified Twitter user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/lists/ownerships
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/create-manage-lists/api-reference/get-lists-ownerships
 
         """
         return self.get('lists/ownerships', params=params)
@@ -905,7 +981,8 @@ class EndpointsMixin(object):
     def get_saved_searches(self, **params):
         """Returns the authenticated user's saved search queries.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/saved_searches/list
+        Docs:
+        https://developer.twitter.com/en/docs/tweets/search/api-reference/get-saved_searches-list
 
         """
         return self.get('saved_searches/list', params=params)
@@ -914,7 +991,7 @@ class EndpointsMixin(object):
         """Retrieve the information for the saved search represented by the given id.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/get/saved_searches/show/%3Aid
+        https://developer.twitter.com/en/docs/tweets/search/api-reference/get-saved_searches-show-id
 
         """
         return self.get('saved_searches/show/%s' % params.get('id'),
@@ -923,7 +1000,8 @@ class EndpointsMixin(object):
     def create_saved_search(self, **params):
         """Create a new saved search for the authenticated user.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/saved_searches/create
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-mutes-users-create
 
         """
         return self.post('saved_searches/create', params=params)
@@ -932,7 +1010,7 @@ class EndpointsMixin(object):
         """Destroys a saved search for the authenticating user.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/post/saved_searches/destroy/%3Aid
+        https://developer.twitter.com/en/docs/tweets/search/api-reference/post-saved_searches-destroy-id
 
         """
         return self.post('saved_searches/destroy/%s' % params.get('id'),
@@ -942,7 +1020,8 @@ class EndpointsMixin(object):
     def get_geo_info(self, **params):
         """Returns all the information about a known place.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/geo/id/%3Aplace_id
+        Docs:
+        https://developer.twitter.com/en/docs/geo/place-information/api-reference/get-geo-id-place_id
 
         """
         return self.get('geo/id/%s' % params.get('place_id'), params=params)
@@ -951,7 +1030,8 @@ class EndpointsMixin(object):
         """Given a latitude and a longitude, searches for up to 20 places
         that can be used as a place_id when updating a status.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/geo/reverse_geocode
+        Docs:
+        https://developer.twitter.com/en/docs/geo/places-near-location/api-reference/get-geo-reverse_geocode
 
         """
         return self.get('geo/reverse_geocode', params=params)
@@ -959,7 +1039,8 @@ class EndpointsMixin(object):
     def search_geo(self, **params):
         """Search for places that can be attached to a statuses/update.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/geo/search
+        Docs:
+        https://developer.twitter.com/en/docs/geo/places-near-location/api-reference/get-geo-search
 
         """
         return self.get('geo/search', params=params)
@@ -985,7 +1066,8 @@ class EndpointsMixin(object):
         """Returns the top 10 trending topics for a specific WOEID, if
         trending information is available for it.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/trends/place
+        Docs:
+        https://developer.twitter.com/en/docs/trends/trends-for-location/api-reference/get-trends-place
 
         """
         return self.get('trends/place', params=params)
@@ -993,7 +1075,8 @@ class EndpointsMixin(object):
     def get_available_trends(self, **params):
         """Returns the locations that Twitter has trending topic information for.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/trends/available
+        Docs:
+        https://developer.twitter.com/en/docs/trends/locations-with-trending-topics/api-reference/get-trends-available
 
         """
         return self.get('trends/available', params=params)
@@ -1002,7 +1085,8 @@ class EndpointsMixin(object):
         """Returns the locations that Twitter has trending topic information
         for, closest to a specified location.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/trends/closest
+        Docs:
+        https://developer.twitter.com/en/docs/trends/locations-with-trending-topics/api-reference/get-trends-closest
 
         """
         return self.get('trends/closest', params=params)
@@ -1011,7 +1095,8 @@ class EndpointsMixin(object):
     def report_spam(self, **params):  # pragma: no cover
         """Report the specified user as a spam account to Twitter.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/users/report_spam
+        Docs:
+        https://developer.twitter.com/en/docs/accounts-and-users/mute-block-report-users/api-reference/post-users-report_spam
 
         """
         return self.post('users/report_spam', params=params)
@@ -1021,7 +1106,8 @@ class EndpointsMixin(object):
         """Allows a registered application to revoke an issued OAuth 2 Bearer
         Token by presenting its client credentials.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/post/oauth2/invalidate_token
+        Docs:
+        https://developer.twitter.com/en/docs/basics/authentication/api-reference/invalidate_token
 
         """
         return self.post('oauth2/invalidate_token', params=params)
@@ -1030,7 +1116,8 @@ class EndpointsMixin(object):
     def get_twitter_configuration(self, **params):
         """Returns the current configuration used by Twitter
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/help/configuration
+        Docs:
+        https://developer.twitter.com/en/docs/developer-utilities/configuration/api-reference/get-help-configuration
 
         """
         return self.get('help/configuration', params=params)
@@ -1039,7 +1126,8 @@ class EndpointsMixin(object):
         """Returns the list of languages supported by Twitter along with
         their ISO 639-1 code.
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/help/languages
+        Docs:
+        https://developer.twitter.com/en/docs/developer-utilities/supported-languages/api-reference/get-help-languages
 
         """
         return self.get('help/languages', params=params)
@@ -1047,7 +1135,8 @@ class EndpointsMixin(object):
     def get_privacy_policy(self, **params):
         """Returns Twitter's Privacy Policy
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/help/privacy
+        Docs:
+        https://developer.twitter.com/en/docs/developer-utilities/privacy-policy/api-reference/get-help-privacy
 
         """
         return self.get('help/privacy', params=params)
@@ -1055,7 +1144,8 @@ class EndpointsMixin(object):
     def get_tos(self, **params):
         """Return the Twitter Terms of Service
 
-        Docs: https://dev.twitter.com/docs/api/1.1/get/help/tos
+        Docs:
+        https://developer.twitter.com/en/docs/developer-utilities/terms-of-service/api-reference/get-help-tos
 
         """
         return self.get('help/tos', params=params)
@@ -1065,13 +1155,13 @@ class EndpointsMixin(object):
         specified resource families.
 
         Docs:
-        https://dev.twitter.com/docs/api/1.1/get/application/rate_limit_status
+        https://developer.twitter.com/en/docs/developer-utilities/rate-limit-status/api-reference/get-application-rate_limit_status
 
         """
         return self.get('application/rate_limit_status', params=params)
 
 
-# from https://dev.twitter.com/docs/error-codes-responses
+# from https://developer.twitter.com/en/docs/ads/general/guides/response-codes
 TWITTER_HTTP_STATUS_CODE = {
     200: ('OK', 'Success!'),
     304: ('Not Modified', 'There was no new data to return.'),

--- a/twython/streaming/api.py
+++ b/twython/streaming/api.py
@@ -169,9 +169,9 @@ class TwythonStreamer(object):
         Returns True if other handlers for this message should be invoked.
 
         Feel free to override this to handle your streaming data how you
-        want it handled.
-        See https://dev.twitter.com/docs/streaming-apis/messages for messages
-        sent along in stream responses.
+        want it handled. See
+        https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types
+        for messages sent along in stream responses.
 
         :param data: data recieved from the stream
         :type data: dict

--- a/twython/streaming/types.py
+++ b/twython/streaming/types.py
@@ -59,7 +59,7 @@ class TwythonStreamerTypesStatuses(object):
         :param \*\*params: Parameters to send with your stream request
 
         Accepted params found at:
-        https://dev.twitter.com/docs/api/1.1/post/statuses/filter
+        https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter
         """
         url = 'https://stream.twitter.com/%s/statuses/filter.json' \
               % self.streamer.api_version
@@ -71,7 +71,7 @@ class TwythonStreamerTypesStatuses(object):
         :param \*\*params: Parameters to send with your stream request
 
         Accepted params found at:
-        https://dev.twitter.com/docs/api/1.1/get/statuses/sample
+        https://developer.twitter.com/en/docs/tweets/sample-realtime/api-reference/get-statuses-sample
         """
         url = 'https://stream.twitter.com/%s/statuses/sample.json' \
               % self.streamer.api_version
@@ -95,7 +95,7 @@ class TwythonStreamerTypesStatuses(object):
         :param \*\*params: Parameters to send with your stream request
 
         Accepted params found at:
-        https://dev.twitter.com/docs/api/1.1/post/statuses/filter
+        https://developer.twitter.com/en/docs/tweets/filter-realtime/api-reference/post-statuses-filter
         """
         self.params = params
 
@@ -104,4 +104,4 @@ class TwythonStreamerTypesStatuses(object):
 
         url = 'https://stream.twitter.com/%s/statuses/filter.json' \
               % self.streamer.api_version
-        self.streamer._request(url, 'POST', params=self.params)	
+        self.streamer._request(url, 'POST', params=self.params)


### PR DESCRIPTION
Addresses #455; lots of Twitter's documentation links have been recently broken. This PR attempts to update URLs to documentation where it can.

The nice part about this task is that one can grep for `dev.twitter.com` and get a list of deprecated/broken links that need fixing.