### PR TITLE
Added support for the new direct message endpoints

### DIFF
--- a/twython/api.py
+++ b/twython/api.py
@@ -153,7 +153,7 @@ class Twython(EndpointsMixin, object):
             if k in ('timeout', 'allow_redirects', 'stream', 'verify'):
                 requests_args[k] = v
 
-        if method == 'get':
+        if method == 'get' or method == 'delete':
             requests_args['params'] = params
         else:
             # Check for json_encoded so we will sent params as "data" or "json"
@@ -242,7 +242,7 @@ class Twython(EndpointsMixin, object):
                          (e.g. search/tweets)
         :type endpoint: string
         :param method: (optional) Method of accessing data, either
-                       GET or POST. (default GET)
+                       GET, POST or DELETE. (default GET)
         :type method: string
         :param params: (optional) Dict of parameters (if any) accepted
                        the by Twitter API endpoint you are trying to
@@ -280,6 +280,10 @@ class Twython(EndpointsMixin, object):
     def post(self, endpoint, params=None, version='1.1', json_encoded=False):
         """Shortcut for POST requests via :class:`request`"""
         return self.request(endpoint, 'POST', params=params, version=version, json_encoded=json_encoded)
+
+    def delete(self, endpoint, params=None, version='1.1', json_encoded=False):
+        """Shortcut for delete requests via :class:`request`"""
+        return self.request(endpoint, 'DELETE', params=params, version=version, json_encoded=json_encoded)
 
     def get_lastfunction_header(self, header, default_return_value=None):
         """Returns a specific header from the last API call

--- a/twython/api.py
+++ b/twython/api.py
@@ -160,7 +160,7 @@ class Twython(EndpointsMixin, object):
             if json_encoded:
                 data_key = 'json'
             else:
-               data_key = 'data'
+                data_key = 'data'
             requests_args.update({
                 data_key: params,
                 'files': files,

--- a/twython/api.py
+++ b/twython/api.py
@@ -135,13 +135,13 @@ class Twython(EndpointsMixin, object):
     def __repr__(self):
         return '<Twython: %s>' % (self.app_key)
 
-    def _request(self, url, method='GET', params=None, api_call=None):
+    def _request(self, url, method='GET', params=None, api_call=None, json_encoded=False):
         """Internal request method"""
         method = method.lower()
         params = params or {}
 
         func = getattr(self.client, method)
-        if isinstance(params, dict):
+        if isinstance(params, dict) and json_encoded == False:
             params, files = _transparent_params(params)
         else:
             params = params
@@ -156,8 +156,13 @@ class Twython(EndpointsMixin, object):
         if method == 'get':
             requests_args['params'] = params
         else:
+            # Check for json_encoded so we will sent params as "data" or "json"
+            if json_encoded:
+                data_key = "json"
+            else:
+               data_key = "data"
             requests_args.update({
-                'data': params,
+                data_key: params,
                 'files': files,
             })
         try:
@@ -230,7 +235,7 @@ class Twython(EndpointsMixin, object):
 
         return error_message
 
-    def request(self, endpoint, method='GET', params=None, version='1.1'):
+    def request(self, endpoint, method='GET', params=None, version='1.1', json_encoded=False):
         """Return dict of response received from Twitter's API
 
         :param endpoint: (required) Full url or Twitter API endpoint
@@ -246,6 +251,9 @@ class Twython(EndpointsMixin, object):
         :param version: (optional) Twitter API version to access
                         (default 1.1)
         :type version: string
+        :param json_encoded: (optional) Flag to indicate if this method should send data encoded as json
+                        (default False)
+        :type json_encoded: bool
 
         :rtype: dict
         """
@@ -261,7 +269,7 @@ class Twython(EndpointsMixin, object):
             url = '%s/%s.json' % (self.api_url % version, endpoint)
 
         content = self._request(url, method=method, params=params,
-                                api_call=url)
+                                api_call=url, json_encoded=json_encoded)
 
         return content
 
@@ -269,9 +277,9 @@ class Twython(EndpointsMixin, object):
         """Shortcut for GET requests via :class:`request`"""
         return self.request(endpoint, params=params, version=version)
 
-    def post(self, endpoint, params=None, version='1.1'):
+    def post(self, endpoint, params=None, version='1.1', json_encoded=False):
         """Shortcut for POST requests via :class:`request`"""
-        return self.request(endpoint, 'POST', params=params, version=version)
+        return self.request(endpoint, 'POST', params=params, version=version, json_encoded=json_encoded)
 
     def get_lastfunction_header(self, header, default_return_value=None):
         """Returns a specific header from the last API call

--- a/twython/api.py
+++ b/twython/api.py
@@ -141,7 +141,7 @@ class Twython(EndpointsMixin, object):
         params = params or {}
 
         func = getattr(self.client, method)
-        if isinstance(params, dict) and json_encoded == False:
+        if isinstance(params, dict) and json_encoded is False:
             params, files = _transparent_params(params)
         else:
             params = params
@@ -158,9 +158,9 @@ class Twython(EndpointsMixin, object):
         else:
             # Check for json_encoded so we will sent params as "data" or "json"
             if json_encoded:
-                data_key = "json"
+                data_key = 'json'
             else:
-               data_key = "data"
+               data_key = 'data'
             requests_args.update({
                 data_key: params,
                 'files': files,

--- a/twython/endpoints.py
+++ b/twython/endpoints.py
@@ -329,10 +329,10 @@ class EndpointsMixin(object):
         """Destroys the direct message specified in the required ``id`` parameter
 
         Docs:
-        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/delete-message-event
 
         """
-        return self.post('direct_messages/destroy', params=params)
+        return self.delete('direct_messages/events/destroy', params=params)
 
     def send_direct_message(self, **params):
         """Sends a new direct message to the specified user from the

--- a/twython/endpoints.py
+++ b/twython/endpoints.py
@@ -300,10 +300,10 @@ class EndpointsMixin(object):
         """Returns the 20 most recent direct messages sent to the authenticating user.
 
         Docs:
-        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-messages
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/list-events
 
         """
-        return self.get('direct_messages', params=params)
+        return self.get('direct_messages/events/list', params=params)
     get_direct_messages.iter_mode = 'id'
 
     def get_sent_messages(self, **params):
@@ -320,10 +320,10 @@ class EndpointsMixin(object):
         """Returns a single direct message, specified by an ``id`` parameter.
 
         Docs:
-        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-message
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/get-event
 
         """
-        return self.get('direct_messages/show', params=params)
+        return self.get('direct_messages/events/show', params=params)
 
     def destroy_direct_message(self, **params):
         """Destroys the direct message specified in the required ``id`` parameter
@@ -339,10 +339,10 @@ class EndpointsMixin(object):
         authenticating user.
 
         Docs:
-        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-message
+        https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event
 
         """
-        return self.post('direct_messages/new', params=params)
+        return self.post('direct_messages/events/new', params=params, json_encoded=True)
 
     # Friends & Followers
     def get_user_ids_of_blocked_retweets(self, **params):


### PR DESCRIPTION
This adds support for the new event based direct messages methods, available after August 16. In particular, get_direct_messages, get_direct_message, send_direct_message and destroy_direct_message were changed to the new methods provided in Twitter. Take into account that new objects (events) are returned for all GET methods related to direct messages, and in order to send a direct message you have to send an event in a dictionary as specified in the [Documentation of this method.](https://developer.twitter.com/en/docs/direct-messages/sending-and-receiving/api-reference/new-event.html) Also, the function get_send_messages should be removed, as is no longer possible to use that endpoint.