### PR TITLE
twitter.cursor: Update params instead of replace them

### DIFF
--- a/twython/api.py
+++ b/twython/api.py
@@ -514,7 +514,7 @@ class Twython(EndpointsMixin, object):
                         metadata = content.get(function.iter_metadata)
                         if 'next_results' in metadata:
                             next_results = urlsplit(metadata['next_results'])
-                            params = dict(parse_qsl(next_results.query))
+                            params.update(dict(parse_qsl(next_results.query)))
                         else:
                             # No more results
                             raise StopIteration


### PR DESCRIPTION
The search since_id param is lost because this params is not present in the next_results query params of the response

```python
    since_id = '10101010101010101'
    results = twitter.cursor(
        twitter.search,
        q=q,
        count=100,
        since_id=since_id,
        result_type="recent",
        tweet_mode='extended'
    )

```
Logs
```
Starting new HTTPS connection (1): api.twitter.com:443
https://api.twitter.com:443 "GET /1.1/search/tweets.json?since_id=10101010101010101&result_type=recent&q=loremipsum&count=100&tweet_mode=extended
https://api.twitter.com:443 "GET /1.1/search/tweets.json?q=loremipsum&max_id=111111111111111111&include_entities=1&result_type=recent&count=100&tweet_mode=extended
```
