### PR TITLE
remove python 2.6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.5
   - 3.6
@@ -20,7 +19,6 @@ env:
   - ACCESS_TOKEN_B64=U2FsdGVkX18QdBhvMNshM4PGy04tU3HLwKP+nNSoNZHKsvGLjELcWEXN2LIu/T+yngX1vGONf9lo14ElnfS4k7sfhiru8phR4+rZuBVP3bDvC2A6fXJuhuLqNhBrWqg32WQewvxLWDWBoKmnvRHg5b74GHh+IN/12tU0cBF2HK8=
 install:
   - pip install -r requirements.txt
-  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
 script: nosetests -v -w tests/ --logging-filter="twython" --with-cov --cov twython --cov-config .coveragerc --cov-report term-missing
 notifications:
   email: false

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ Twython
 .. image:: https://img.shields.io/coveralls/ryanmcgrath/twython/master.svg?style=flat-square
   :target: https://coveralls.io/r/ryanmcgrath/twython?branch=master
 
-``Twython`` is the premier Python library providing an easy (and up-to-date) way to access Twitter data. Actively maintained and featuring support for Python 2.6+ and Python 3. It's been battle tested by companies, educational institutions and individuals alike. Try it today!
+``Twython`` is the premier Python library providing an easy (and up-to-date) way to access Twitter data. Actively maintained and featuring support for Python 2.7 and Python 3. It's been battle tested by companies, educational institutions and individuals alike. Try it today!
 
 Features
 --------


### PR DESCRIPTION
Travis logs
```
DEPRECATION: Python 2.6 is no longer supported by the Python core team, please upgrade your Python. A future version of pip will drop support for Python 2.6
```

``` 
requests-oauthlib requires Python '>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*' but the running Python is 2.6.9
The command "pip install -r requirements.txt" failed and exited with 1 during .
```