### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/usage/advanced_usage.rst
+++ b/docs/usage/advanced_usage.rst
@@ -104,7 +104,7 @@ Manipulate the Request (headers, proxies, etc.)
 
 There are times when you may want to turn SSL verification off, send custom headers, or add proxies for the request to go through.
 
-Twython uses the `requests <http://python-requests.org>`_ library to make API calls to Twitter. ``requests`` accepts a few parameters to allow developers to manipulate the acutal HTTP request.
+Twython uses the `requests <http://python-requests.org>`_ library to make API calls to Twitter. ``requests`` accepts a few parameters to allow developers to manipulate the actual HTTP request.
 
 Here is an example of sending custom headers to a Twitter API request:
 

--- a/docs/usage/basic_usage.rst
+++ b/docs/usage/basic_usage.rst
@@ -80,7 +80,7 @@ Documentation: https://developer.twitter.com/en/docs/tweets/search/api-reference
 
 .. _dynamicargexplaination:
 
-.. important:: To help explain :ref:`dynamic function arguments <dynamicfunctionarguments>` a little more, you can see that the previous call used the keyword argument ``q``, that is because Twitter specifies in their `search documentation <https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets>`_ that the search call accepts the parameter "q". You can pass mutiple keyword arguments. The search documentation also specifies that the call accepts the parameter "result_type"
+.. important:: To help explain :ref:`dynamic function arguments <dynamicfunctionarguments>` a little more, you can see that the previous call used the keyword argument ``q``, that is because Twitter specifies in their `search documentation <https://developer.twitter.com/en/docs/tweets/search/api-reference/get-search-tweets>`_ that the search call accepts the parameter "q". You can pass multiple keyword arguments. The search documentation also specifies that the call accepts the parameter "result_type"
 
 .. code-block:: python
 

--- a/docs/usage/special_functions.rst
+++ b/docs/usage/special_functions.rst
@@ -10,7 +10,7 @@ This section covers methods to are part of Twython but not necessarily connected
 Cursor
 ------
 
-This function returns a generator for Twitter API endpoints that are able to be pagintated in some way (either by cursor or since_id parameter)
+This function returns a generator for Twitter API endpoints that are able to be paginated in some way (either by cursor or since_id parameter)
 
 The Old Way
 ^^^^^^^^^^^
@@ -91,7 +91,7 @@ will be replaced with:
 
     <a href="http://t.co/FCmXyI6VHd" class="twython-url">google.com</a> is <a href="https://twitter.com/search?q=%23cool" class="twython-hashtag">#cool</a>, lol! <a href="https://twitter.com/mikehelmick" class="twython-mention">@mikehelmick</a> shd <a href="https://twitter.com/search?q=%23checkitout" class="twython-hashtag">#checkitout</a>. Love, <a href="https://twitter.com/__twython__" class="twython-mention">@__twython__</a> <a href="https://twitter.com/?q=%24IBM" class="twython-symbol">$IBM</a> <a href="https://t.co/67pwRvY6z9" class="twython-url">github.com</a> <a href="http://t.co/N6InAO4B71" class="twython-media">pic.twitter.com/N6InAO4B71</a>
 
-.. note:: When converting the string to HTML we add a class to each HTML tag so that you can maninpulate the DOM later on.
+.. note:: When converting the string to HTML we add a class to each HTML tag so that you can manipulate the DOM later on.
 
 - For urls that are replaced we add ``class="twython-url"`` to the anchor tag
 - For media urls that are replaced we add ``class="twython-media"`` to the anchor tag

--- a/docs/usage/starting_out.rst
+++ b/docs/usage/starting_out.rst
@@ -74,7 +74,7 @@ Handling the Callback
 
 .. note:: If your application is a Desktop or Mobile Application *oauth_verifier* will be the PIN code
 
-After they authorize your application to access some of their account details, they'll be redirected to the callback url you specified in ``get_autentication_tokens``
+After they authorize your application to access some of their account details, they'll be redirected to the callback url you specified in ``get_authentication_tokens``
 
 You'll want to extract the ``oauth_verifier`` from the url.
 

--- a/tests/test_endpoints.py
+++ b/tests/test_endpoints.py
@@ -119,7 +119,7 @@ class TwythonEndpointsTestCase(unittest.TestCase):
 
     @unittest.skip('skipping non-updated test')
     def test_send_get_and_destroy_direct_message(self):
-        """Test sending, getting, then destory a direct message succeeds"""
+        """Test sending, getting, then destroy a direct message succeeds"""
         message = self.api.send_direct_message(screen_name=protected_twitter_1,
                                                text='Hey d00d! %s\
                                                ' % int(time.time()))
@@ -395,7 +395,7 @@ class TwythonEndpointsTestCase(unittest.TestCase):
 
     @unittest.skip('skipping non-updated test')
     def test_get_list_memberships(self):
-        """Test list of memberhips the authenticated user succeeds"""
+        """Test list of membership the authenticated user succeeds"""
         self.api.get_list_memberships()
 
     @unittest.skip('skipping non-updated test')

--- a/twython/endpoints.py
+++ b/twython/endpoints.py
@@ -230,7 +230,7 @@ class EndpointsMixin(object):
 
         response = self.post(upload_url, params=params)
 
-        # Only get the status if explicity asked to
+        # Only get the status if explicitly asked to
         # Default to False
         if check_progress:
 

--- a/twython/streaming/api.py
+++ b/twython/streaming/api.py
@@ -171,7 +171,7 @@ class TwythonStreamer(object):
         https://developer.twitter.com/en/docs/tweets/filter-realtime/guides/streaming-message-types
         for messages sent along in stream responses.
 
-        :param data: data recieved from the stream
+        :param data: data received from the stream
         :type data: dict
         """
         return True


### PR DESCRIPTION
There are small typos in:
- docs/usage/advanced_usage.rst
- docs/usage/basic_usage.rst
- docs/usage/special_functions.rst
- docs/usage/starting_out.rst
- tests/test_endpoints.py
- twython/endpoints.py
- twython/streaming/api.py

Fixes:
- Should read `received` rather than `recieved`.
- Should read `paginated` rather than `pagintated`.
- Should read `multiple` rather than `mutiple`.
- Should read `membership` rather than `memberhips`.
- Should read `manipulate` rather than `maninpulate`.
- Should read `explicitly` rather than `explicity`.
- Should read `destroy` rather than `destory`.
- Should read `authentication` rather than `autentication`.
- Should read `actual` rather than `acutal`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md